### PR TITLE
Coverage report via Coveralls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/ucfopen/faculty-tools.svg?branch=master)](https://travis-ci.org/ucfopen/faculty-tools)
+[![Coverage Status](https://coveralls.io/repos/github/ucfopen/faculty-tools/badge.svg?branch=master)](https://coveralls.io/github/ucfopen/faculty-tools?branch=master)
 [![Join UCF Open Slack Discussions](https://ucf-open-slackin.herokuapp.com/badge.svg)](https://ucf-open-slackin.herokuapp.com/)
 
 # Documentation for Faculty Tools

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ max_line_length=99
 ignore = W503, E203
 
 [coverage:run]
+source = .
 omit=
 	venv*/*
 	env/*


### PR DESCRIPTION
It turns out we were already running the `coveralls` command in the CI file, just needed to turn it on on their site. Made a few related adjustments:

- Add CI status and coverage badges to readme.
- Specify coverage source directory

Resolves #8 